### PR TITLE
feat: use commit authors connection to include co-authors in notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,54 @@ However, when the PR author is a bot, no one receives these notifications. As a 
 This becomes particularly problematic in teams that follow the convention that `it is the author—not the reviewer—who is responsible for merging the PR`.
 
 **notify-bot-pr-event-action** addresses this problem by posting comments on the PR when events such as reviews, merges, or closures occur. It mentions relevant users—such as committers or assignees—to ensure that humans are properly notified about these events.
+
+## Notified Events
+
+- pull_request_review
+  - approved
+  - request changes
+  - comment
+- pull_request
+  - merged
+  - closed
+
+## Notified Users
+
+- committers
+- commit author
+- commit co-authors
+- assignees
+- approvers
+
+The following users are excluded.
+
+- `github.actor`
+- machine_users
+- GitHub Apps
+
+## How To Use
+
+```yaml
+---
+name: Notify bot pr event
+on:
+  pull_request:
+    types: [closed]
+  pull_request_review:
+    types: [submitted]
+jobs:
+  notify-bot-pr-event:
+    # Filter events
+    # pr author: Bot
+    if: |
+      endsWith(github.event.pull_request.user.login, '[bot]') &&
+      ((github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
+      github.event_name == 'pull_request')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      pull-requests: write # To post pr comments
+      contents: read # To read commits
+    steps:
+      - uses: suzuki-shunsuke/notify-bot-pr-event-action@latest
+```

--- a/src/github.ts
+++ b/src/github.ts
@@ -48,10 +48,12 @@ export const getPullRequest = async (
                 resourcePath
               }
             }
-            author {
-              user {
-                login
-                resourcePath
+            authors(first: 100) {
+              nodes {
+                user {
+                  login
+                  resourcePath
+                }
               }
             }
           }
@@ -113,10 +115,12 @@ export const listCommits = async (
                 resourcePath
               }
             }
-            author {
-              user {
-                login
-                resourcePath
+            authors(first: 100) {
+              nodes {
+                user {
+                  login
+                  resourcePath
+                }
               }
             }
           }

--- a/src/run.ts
+++ b/src/run.ts
@@ -87,8 +87,10 @@ const collectUsersToNotify = (
     if (node.commit.committer.user) {
       users.add(node.commit.committer.user.login);
     }
-    if (node.commit.author.user) {
-      users.add(node.commit.author.user.login);
+    for (const author of node.commit.authors.nodes) {
+      if (author.user) {
+        users.add(author.user.login);
+      }
     }
   }
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -20,8 +20,12 @@ const Commit = z.object({
   committer: z.object({
     user: z.nullable(User),
   }),
-  author: z.object({
-    user: z.nullable(User),
+  authors: z.object({
+    nodes: z.array(
+      z.object({
+        user: z.nullable(User),
+      }),
+    ),
   }),
 });
 export type Commit = z.infer<typeof Commit>;


### PR DESCRIPTION
## Summary

- Switch GraphQL queries from single `author` to `authors(first: 100)` connection field so that co-authors (added via `Co-Authored-By:` commit trailers) are also included in notifications
- Update Zod schema (`Commit.authors`) and business logic (`collectUsersToNotify`) to iterate over the authors array
- Update README with usage documentation

## Test plan

- [ ] Verify `npm run build` succeeds with no type errors
- [ ] Test with a PR containing co-authored commits to confirm co-authors receive notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)