### PR TITLE
Update action runtime to Node 24

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -18,5 +18,5 @@ inputs:
       Note: Users with [bot] in their login are automatically excluded.
     required: false
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
## Summary

Update the GitHub Action runtime from Node.js 20 to Node.js 24.

## Why

GitHub Actions is deprecating Node.js 20 for JavaScript actions, so this action should declare the supported Node.js 24 runtime.

## Impact

Users of the action will run the existing bundled entrypoint with the Node.js 24 action runtime. The repository already uses Node.js 24 tooling.

## Validation

- `npm ci --cache /tmp/npm-cache-notify-bot-pr-event-action`
- `npm test`
- `npm run build`